### PR TITLE
Fix game refocus on touch for entire-monitor RefocusDisplay panels

### DIFF
--- a/WindowsAgent/TouchEventManager.cs
+++ b/WindowsAgent/TouchEventManager.cs
@@ -97,8 +97,11 @@ namespace MSFSPopoutPanelManager.WindowsAgent
             }
 
             // If touch point is within pop out panel boundaries and have touch enabled.
-            // RefocusDisplay panels are always included - they have TouchEnabled = false but still need touch handling.
-            var panelConfig = ActiveProfile.PanelConfigs.FirstOrDefault(p => (p.TouchEnabled || p.PanelType == PanelType.RefocusDisplay) &&
+            // Prefer a touch-enabled pop out panel; fall back to a RefocusDisplay panel (which covers a whole
+            // monitor and therefore overlaps every other panel on it) only when no touch panel matches.
+            var panelConfig = ActiveProfile.PanelConfigs.FirstOrDefault(p => p.TouchEnabled &&
+                                                                            ((p.FullScreen && CheckWithinFullScreenCoordinate(p, info)) || CheckWithinWindowCoordinate(p, info)))
+                              ?? ActiveProfile.PanelConfigs.FirstOrDefault(p => p.PanelType == PanelType.RefocusDisplay &&
                                                                             ((p.FullScreen && CheckWithinFullScreenCoordinate(p, info)) || CheckWithinWindowCoordinate(p, info)));
 
             if (panelConfig == null)

--- a/WindowsAgent/TouchEventManager.cs
+++ b/WindowsAgent/TouchEventManager.cs
@@ -96,8 +96,9 @@ namespace MSFSPopoutPanelManager.WindowsAgent
                 return PInvoke.CallNextHookEx(_hHook, code, wParam, lParam);
             }
 
-            // If touch point is within pop out panel boundaries and have touch enabled
-            var panelConfig = ActiveProfile.PanelConfigs.FirstOrDefault(p => p.TouchEnabled &&
+            // If touch point is within pop out panel boundaries and have touch enabled.
+            // RefocusDisplay panels are always included - they have TouchEnabled = false but still need touch handling.
+            var panelConfig = ActiveProfile.PanelConfigs.FirstOrDefault(p => (p.TouchEnabled || p.PanelType == PanelType.RefocusDisplay) &&
                                                                             ((p.FullScreen && CheckWithinFullScreenCoordinate(p, info)) || CheckWithinWindowCoordinate(p, info)));
 
             if (panelConfig == null)
@@ -107,12 +108,16 @@ namespace MSFSPopoutPanelManager.WindowsAgent
             {
                 case WM_RBUTTONDOWN:
                 case WM_RBUTTONUP:
+                    // Let right-click pass through to the underlying app (eg. Air Manager) on a RefocusDisplay monitor
+                    if (panelConfig.PanelType == PanelType.RefocusDisplay)
+                        return PInvoke.CallNextHookEx(_hHook, code, wParam, lParam);
                     return 1;
 
-                case WM_LBUTTONDOWN:                                        
+                case WM_LBUTTONDOWN:
                     _refocusedTaskIndex++;
+                    // Pass the touch through so the underlying app receives it, then refocus happens on touch up
                     if (panelConfig.PanelType == PanelType.RefocusDisplay)
-                        return 1;
+                        return PInvoke.CallNextHookEx(_hHook, code, wParam, lParam);
                 
                     Task.Run(() =>
                     {
@@ -149,6 +154,9 @@ namespace MSFSPopoutPanelManager.WindowsAgent
                                 }
                             }
                         });
+
+                        // Pass the touch up through so the underlying app (eg. Air Manager) receives it
+                        return PInvoke.CallNextHookEx(_hHook, code, wParam, lParam);
                     }
                     else
                     {
@@ -217,9 +225,14 @@ namespace MSFSPopoutPanelManager.WindowsAgent
 
         private static bool CheckWithinWindowCoordinate(PanelConfig panelConfig, MSLLHOOKSTRUCT coor)
         {
+            // RefocusDisplay covers a whole monitor and has no title bar - don't reserve the menu bar strip at the top
+            var topOffset = panelConfig.PanelType == PanelType.RefocusDisplay
+                ? 0
+                : (panelConfig.HideTitlebar ? 1 : PANEL_MENUBAR_HEIGHT);
+
             return coor.pt.X > panelConfig.Left
                    && coor.pt.X < panelConfig.Left + panelConfig.Width
-                   && coor.pt.Y > panelConfig.Top + (panelConfig.HideTitlebar ? 1 : PANEL_MENUBAR_HEIGHT)
+                   && coor.pt.Y > panelConfig.Top + topOffset
                    && coor.pt.Y < panelConfig.Top + panelConfig.Height;
         }
 

--- a/WindowsAgent/TouchEventManager.cs
+++ b/WindowsAgent/TouchEventManager.cs
@@ -97,11 +97,8 @@ namespace MSFSPopoutPanelManager.WindowsAgent
             }
 
             // If touch point is within pop out panel boundaries and have touch enabled.
-            // Prefer a touch-enabled pop out panel; fall back to a RefocusDisplay panel (which covers a whole
-            // monitor and therefore overlaps every other panel on it) only when no touch panel matches.
-            var panelConfig = ActiveProfile.PanelConfigs.FirstOrDefault(p => p.TouchEnabled &&
-                                                                            ((p.FullScreen && CheckWithinFullScreenCoordinate(p, info)) || CheckWithinWindowCoordinate(p, info)))
-                              ?? ActiveProfile.PanelConfigs.FirstOrDefault(p => p.PanelType == PanelType.RefocusDisplay &&
+            // RefocusDisplay panels are always included - they have TouchEnabled = false but still need touch handling.
+            var panelConfig = ActiveProfile.PanelConfigs.FirstOrDefault(p => (p.TouchEnabled || p.PanelType == PanelType.RefocusDisplay) &&
                                                                             ((p.FullScreen && CheckWithinFullScreenCoordinate(p, info)) || CheckWithinWindowCoordinate(p, info)));
 
             if (panelConfig == null)


### PR DESCRIPTION
The "Enable entire monitor display to have game refocus function when touch" feature did not refocus MSFS when touching apps such as Air Manager. The WH_MOUSE_LL touch hook only handled panels with TouchEnabled = true, but RefocusDisplay panels are created with TouchEnabled = false, so its RefocusDisplay handling was unreachable.

- Include RefocusDisplay panels in the touch-hook panel lookup.
- Pass touch/right-click input through to the underlying app for RefocusDisplay panels instead of swallowing it, so the panel still responds while the delayed game refocus is scheduled.
- Skip the 31px title-bar dead-strip at the top edge for whole-monitor RefocusDisplay panels.

Demo video: https://www.youtube.com/watch?v=j_81rx5IWqY