### PR TITLE
Streaming panels over http

### DIFF
--- a/DomainModel/Profile/PanelConfig.cs
+++ b/DomainModel/Profile/PanelConfig.cs
@@ -70,6 +70,8 @@ namespace MSFSPopoutPanelManager.DomainModel.Profile
 
         public bool AutoGameRefocus { get; set; } = true;
 
+        public bool EnableStreaming { get; set; } = true;
+
         public FloatingPanel FloatingPanel { get; set; } = new();
 
         public PanelSource PanelSource { get; set; } = new();

--- a/DomainModel/Profile/PanelConfigItem.cs
+++ b/DomainModel/Profile/PanelConfigItem.cs
@@ -23,6 +23,7 @@ namespace MSFSPopoutPanelManager.DomainModel.Profile
         AutoGameRefocus,
         AllowFloatPanel,
         IsHiddenOnStart,
+        EnableStreaming,
         None
     }
 }

--- a/DomainModel/Setting/ApplicationSetting.cs
+++ b/DomainModel/Setting/ApplicationSetting.cs
@@ -36,6 +36,8 @@ namespace MSFSPopoutPanelManager.DomainModel.Setting
 
         public KeyboardShortcutSetting KeyboardShortcutSetting { get; set; } = new();
 
+        public StreamingSetting StreamingSetting { get; set; } = new();
+
         public event EventHandler<bool> OnIsUsedKeyboardShortcutChanged;
     }
 }

--- a/DomainModel/Setting/StreamingSetting.cs
+++ b/DomainModel/Setting/StreamingSetting.cs
@@ -6,5 +6,6 @@ namespace MSFSPopoutPanelManager.DomainModel.Setting
     {
         public bool IsEnabled { get; set; } = false;
         public int Port { get; set; } = 8080;
+        public string HostOverride { get; set; } = "";
     }
 }

--- a/DomainModel/Setting/StreamingSetting.cs
+++ b/DomainModel/Setting/StreamingSetting.cs
@@ -1,0 +1,10 @@
+using MSFSPopoutPanelManager.Shared;
+
+namespace MSFSPopoutPanelManager.DomainModel.Setting
+{
+    public class StreamingSetting : ObservableObject
+    {
+        public bool IsEnabled { get; set; } = false;
+        public int Port { get; set; } = 8080;
+    }
+}

--- a/MainApp/App.xaml.cs
+++ b/MainApp/App.xaml.cs
@@ -61,12 +61,13 @@ namespace MSFSPopoutPanelManager.MainApp
                         services.AddSingleton(s => new FlightSimOrchestrator(SharedStorage));
                         services.AddSingleton(_ => new KeyboardOrchestrator(SharedStorage));
                         services.AddSingleton(_ => new HelpOrchestrator());
+                        services.AddSingleton(s => new StreamingOrchestrator(SharedStorage, s.GetRequiredService<PanelPopOutOrchestrator>()));
 
                         services.AddSingleton(s => new OrchestratorUiHelper(SharedStorage, s.GetRequiredService<PanelSourceOrchestrator>(), s.GetRequiredService<PanelPopOutOrchestrator>()));
                         services.AddSingleton(s => new ApplicationViewModel(SharedStorage, s.GetRequiredService<AppOrchestrator>()));
                         services.AddSingleton(s => new HelpViewModel(SharedStorage, s.GetRequiredService<HelpOrchestrator>()));
                         services.AddSingleton(s => new ProfileCardListViewModel(SharedStorage));
-                        services.AddSingleton(s => new ProfileCardViewModel(SharedStorage, s.GetRequiredService<ProfileOrchestrator>(), s.GetRequiredService<PanelSourceOrchestrator>(), s.GetRequiredService<PanelConfigurationOrchestrator>(), s.GetRequiredService<PanelPopOutOrchestrator>()));
+                        services.AddSingleton(s => new ProfileCardViewModel(SharedStorage, s.GetRequiredService<ProfileOrchestrator>(), s.GetRequiredService<PanelSourceOrchestrator>(), s.GetRequiredService<PanelConfigurationOrchestrator>(), s.GetRequiredService<PanelPopOutOrchestrator>(), s.GetRequiredService<StreamingOrchestrator>()));
                         services.AddSingleton(s => new TrayIconViewModel(SharedStorage, s.GetRequiredService<AppOrchestrator>(), s.GetRequiredService<PanelPopOutOrchestrator>()));
                         services.AddSingleton(s => new PreferenceDrawerViewModel(SharedStorage, s.GetRequiredService<KeyboardOrchestrator>()));
 

--- a/MainApp/AppUserControl/PopOutPanelConfigCard.xaml
+++ b/MainApp/AppUserControl/PopOutPanelConfigCard.xaml
@@ -309,6 +309,19 @@
                                 </TextBlock>
                             </WrapPanel>
                         </StackPanel>
+                        <ToggleButton
+                            x:Name="TglBtnEnableStreaming"
+                            Margin="20,0,0,0"
+                            VerticalAlignment="Center"
+                            IsChecked="{Binding DataItem.EnableStreaming, Mode=TwoWay, NotifyOnSourceUpdated=True}"
+                            SourceUpdated="Data_SourceUpdated"
+                            Style="{StaticResource ToggleButton}" />
+                        <TextBlock
+                            Margin="5,4,10,4"
+                            Style="{StaticResource TextBlockLabel}"
+                            ToolTip="Include this panel in LAN streaming">
+                            Stream Panel
+                        </TextBlock>
                     </WrapPanel>
                 </Border>
             </StackPanel>

--- a/MainApp/AppUserControl/PreferenceDrawer.xaml
+++ b/MainApp/AppUserControl/PreferenceDrawer.xaml
@@ -515,6 +515,20 @@
                             </TextBlock>
                         </DockPanel>
                     </StackPanel>
+                    <TextBlock Style="{StaticResource TextBlockHeading}">Security Notice</TextBlock>
+                    <Line />
+                    <TextBlock
+                        Margin="0,4,0,0"
+                        Style="{StaticResource TextBlockLabel}"
+                        TextWrapping="Wrap">
+                         Panel streaming has no authentication, so anyone who can reach this port can view the panel streams.
+                    </TextBlock>
+                    <TextBlock
+                        Margin="0,4,0,12"
+                        Style="{StaticResource TextBlockLabel}"
+                        TextWrapping="Wrap">
+                         Use streaming feature only on a trusted home or office network.
+                    </TextBlock>
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>

--- a/MainApp/AppUserControl/PreferenceDrawer.xaml
+++ b/MainApp/AppUserControl/PreferenceDrawer.xaml
@@ -497,6 +497,24 @@
                             </TextBlock>
                         </DockPanel>
                     </StackPanel>
+                    <StackPanel Style="{StaticResource SectionHeader}">
+                        <TextBlock Style="{StaticResource TextBlockHeading}">Host / Address Override</TextBlock>
+                        <Line />
+                        <DockPanel>
+                            <TextBox
+                                Width="200"
+                                Height="24"
+                                Padding="4,2"
+                                Style="{StaticResource TextBox}"
+                                Text="{Binding AppSettingData.ApplicationSetting.StreamingSetting.HostOverride, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                            <TextBlock
+                                Width="520"
+                                Margin="10,0,0,0"
+                                Style="{StaticResource TextBlockLabel}">
+                                Hostname or IP address used in panel stream URLs. Leave blank to detect automatically.
+                            </TextBlock>
+                        </DockPanel>
+                    </StackPanel>
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>

--- a/MainApp/AppUserControl/PreferenceDrawer.xaml
+++ b/MainApp/AppUserControl/PreferenceDrawer.xaml
@@ -36,6 +36,7 @@
                 <TreeViewItem x:Name="CategoryTrackIrSettings" Header="Track IR Settings" />
                 <TreeViewItem x:Name="CategoryWindowedModeSettings" Header="Windowed Mode Settings" />
                 <TreeViewItem x:Name="ChasePlaneSettings" Header="ChasePlane Settings" />
+                <TreeViewItem x:Name="CategoryStreamingSettings" Header="Streaming Settings" />
             </TreeView>
         </ScrollViewer>
 
@@ -470,7 +471,29 @@
                         <DockPanel>
                             <ToggleButton IsChecked="{Binding AppSettingData.ApplicationSetting.ChasePlaneSetting.IsEnabled, Mode=TwoWay}" Style="{StaticResource ToggleButton}" />
                             <TextBlock Style="{StaticResource TextBlockLabel}">
-                                 Enable use of ChasePlane camera view. This setting will apply to all aircraft profiles. You will need to edit panel source for all existing profiles to realign the location of each panel once this setthing is turned on. Re-editing panel source is needed because this step will add additional ChasePlane information to aircraft profiles. 
+                                 Enable use of ChasePlane camera view. This setting will apply to all aircraft profiles. You will need to edit panel source for all existing profiles to realign the location of each panel once this setthing is turned on. Re-editing panel source is needed because this step will add additional ChasePlane information to aircraft profiles.
+                            </TextBlock>
+                        </DockPanel>
+                    </StackPanel>
+                </StackPanel>
+
+                <!--  Streaming Settings  -->
+                <StackPanel Orientation="Vertical" Visibility="{Binding ElementName=CategoryStreamingSettings, Path=IsSelected, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}">
+                    <StackPanel Style="{StaticResource SectionHeader}">
+                        <TextBlock Style="{StaticResource TextBlockHeading}">HTTP Port</TextBlock>
+                        <Line />
+                        <DockPanel>
+                            <TextBox
+                                Width="90"
+                                Height="24"
+                                Padding="4,2"
+                                Style="{StaticResource TextBox}"
+                                Text="{Binding AppSettingData.ApplicationSetting.StreamingSetting.Port, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                            <TextBlock
+                                Width="630"
+                                Margin="10,0,0,0"
+                                Style="{StaticResource TextBlockLabel}">
+                                Port the HTTP streaming server listens on. Change this if port 8080 is already in use. Takes effect after restarting the application.
                             </TextBlock>
                         </DockPanel>
                     </StackPanel>

--- a/MainApp/AppUserControl/ProfileCard.xaml
+++ b/MainApp/AppUserControl/ProfileCard.xaml
@@ -323,12 +323,8 @@
             </DockPanel>
 
             <StackPanel Grid.Row="2" Background="#444444">
-                <StackPanel Margin="24,2,0,0" Orientation="Horizontal">
-                    <TextBlock
-                        FontSize="14"
-                        Style="{StaticResource TextBlockBody}"
-                        Text="Pop Out Panels" />
-                    <StackPanel Margin="723,0,0,0" Orientation="Horizontal" d:IsLocked="True">
+                <DockPanel Margin="24,2,0,0">
+                    <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" d:IsLocked="True">
                         <ToggleButton
                             materialDesign:ToggleButtonAssist.OnContent="{materialDesign:PackIcon Kind=CrosshairsGps}"
                             Command="{Binding ToggleEditPanelSourceCommand}"
@@ -354,8 +350,31 @@
                             ToolTip="Lock and unlock pop out panel settings">
                             <materialDesign:PackIcon Kind="UnlockedOutline" />
                         </ToggleButton>
+                        <ToggleButton
+                            Margin="6,0,0,0"
+                            materialDesign:ToggleButtonAssist.OnContent="{materialDesign:PackIcon Kind=Cast}"
+                            Command="{Binding ToggleStreamingCommand}"
+                            IsChecked="{Binding AppSettingData.ApplicationSetting.StreamingSetting.IsEnabled, Mode=TwoWay}"
+                            Style="{StaticResource IconToggleButton}"
+                            ToolTip="Enable LAN streaming for marked panels"
+                            Visibility="{c:Binding 'ActiveProfile != null and ActiveProfile.PanelConfigs.Count > 0'}">
+                            <materialDesign:PackIcon Kind="CastOff" />
+                        </ToggleButton>
+                        <Button
+                            Margin="4,0,0,0"
+                            Command="{Binding OpenStreamIndexCommand}"
+                            Style="{StaticResource IconButton}"
+                            ToolTip="{Binding StreamIndexUrl}"
+                            Visibility="{c:Binding 'AppSettingData.ApplicationSetting.StreamingSetting.IsEnabled and ActiveProfile != null and ActiveProfile.PanelConfigs.Count > 0'}">
+                            <materialDesign:PackIcon Kind="OpenInNew" />
+                        </Button>
                     </StackPanel>
-                </StackPanel>
+                    <TextBlock
+                        FontSize="14"
+                        Style="{StaticResource TextBlockBody}"
+                        Text="Pop Out Panels"
+                        VerticalAlignment="Center" />
+                </DockPanel>
                 <appUserControl:PopOutPanelListEmpty Padding="0,0,0,10" Visibility="{c:Binding 'ActiveProfile.PanelConfigs.Count == 0'}" />
                 <appUserControl:PopOutPanelList Padding="0,0,0,10" Visibility="{c:Binding 'ActiveProfile.PanelConfigs.Count > 0'}" />
             </StackPanel>

--- a/MainApp/ViewModel/ProfileCardViewModel.cs
+++ b/MainApp/ViewModel/ProfileCardViewModel.cs
@@ -17,6 +17,7 @@ namespace MSFSPopoutPanelManager.MainApp.ViewModel
         private readonly PanelSourceOrchestrator _panelSourceOrchestrator;
         private readonly PanelConfigurationOrchestrator _panelConfigurationOrchestrator;
         private readonly PanelPopOutOrchestrator _panelPopOutOrchestrator;
+        private readonly StreamingOrchestrator _streamingOrchestrator;
 
         public ICommand AddProfileCommand { get; }
 
@@ -38,6 +39,12 @@ namespace MSFSPopoutPanelManager.MainApp.ViewModel
 
         public ICommand IncludeInGamePanelUpdatedCommand { get; }
 
+        public ICommand ToggleStreamingCommand { get; }
+
+        public ICommand OpenStreamIndexCommand { get; }
+
+        public string StreamIndexUrl => $"http://localhost:{AppSettingData.ApplicationSetting.StreamingSetting.Port}/";
+
         public ICommand RefocusDisplayUpdatedCommand { get; }
 
         public ICommand AddNumPadUpdatedCommand { get; }
@@ -52,12 +59,13 @@ namespace MSFSPopoutPanelManager.MainApp.ViewModel
         
         public event EventHandler OnProfileSelected;
 
-        public ProfileCardViewModel(SharedStorage sharedStorage, ProfileOrchestrator profileOrchestrator, PanelSourceOrchestrator panelSourceOrchestrator, PanelConfigurationOrchestrator panelConfigurationOrchestrator, PanelPopOutOrchestrator panelPopOutOrchestrator) : base(sharedStorage)
+        public ProfileCardViewModel(SharedStorage sharedStorage, ProfileOrchestrator profileOrchestrator, PanelSourceOrchestrator panelSourceOrchestrator, PanelConfigurationOrchestrator panelConfigurationOrchestrator, PanelPopOutOrchestrator panelPopOutOrchestrator, StreamingOrchestrator streamingOrchestrator) : base(sharedStorage)
         {
             _profileOrchestrator = profileOrchestrator;
             _panelSourceOrchestrator = panelSourceOrchestrator;
             _panelConfigurationOrchestrator = panelConfigurationOrchestrator;
             _panelPopOutOrchestrator = panelPopOutOrchestrator;
+            _streamingOrchestrator = streamingOrchestrator;
 
             AddProfileCommand = new DelegateCommand(OnAddProfile, () => ProfileData != null && ActiveProfile != null && !ActiveProfile.IsPopOutInProgress)
                                                                                 .ObservesProperty(() => ActiveProfile)
@@ -76,6 +84,12 @@ namespace MSFSPopoutPanelManager.MainApp.ViewModel
                                                                                 .ObservesProperty(() => ProfileData.IsAllowedAddAircraftBinding)
                                                                                 .ObservesProperty(() => FlightSimData.IsSimulatorStarted)
                                                                                 .ObservesProperty(() => ActiveProfile.IsPopOutInProgress);
+
+            ToggleStreamingCommand = new DelegateCommand(OnToggleStreaming, () => ProfileData != null && ActiveProfile != null && ActiveProfile.PanelConfigs.Count > 0)
+                                                                                .ObservesProperty(() => ActiveProfile)
+                                                                                .ObservesProperty(() => ActiveProfile.PanelConfigs.Count);
+
+            OpenStreamIndexCommand = new DelegateCommand(OnOpenStreamIndex);
 
             ToggleLockProfileCommand = new DelegateCommand(OnToggleLockProfile, () => ProfileData != null && ActiveProfile != null && ActiveProfile.PanelConfigs.Count > 0 && !ActiveProfile.IsPopOutInProgress)
                                                                                 .ObservesProperty(() => ActiveProfile)
@@ -157,6 +171,16 @@ namespace MSFSPopoutPanelManager.MainApp.ViewModel
                 _profileOrchestrator.AddProfileBinding(FlightSimData.AircraftName);
             else
                 _profileOrchestrator.DeleteProfileBinding(FlightSimData.AircraftName);
+        }
+
+        private void OnToggleStreaming()
+        {
+            _streamingOrchestrator.ApplyMasterToggle(AppSettingData.ApplicationSetting.StreamingSetting.IsEnabled);
+        }
+
+        private void OnOpenStreamIndex()
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(StreamIndexUrl) { UseShellExecute = true });
         }
 
         private void OnToggleLockProfile()

--- a/MainApp/ViewModel/ProfileCardViewModel.cs
+++ b/MainApp/ViewModel/ProfileCardViewModel.cs
@@ -43,7 +43,7 @@ namespace MSFSPopoutPanelManager.MainApp.ViewModel
 
         public ICommand OpenStreamIndexCommand { get; }
 
-        public string StreamIndexUrl => $"http://localhost:{AppSettingData.ApplicationSetting.StreamingSetting.Port}/";
+        public string StreamIndexUrl => _streamingOrchestrator.GetIndexUrl();
 
         public ICommand RefocusDisplayUpdatedCommand { get; }
 

--- a/Orchestration/StreamingOrchestrator.cs
+++ b/Orchestration/StreamingOrchestrator.cs
@@ -84,7 +84,10 @@ namespace MSFSPopoutPanelManager.Orchestration
                 var liveKeys = LivePanels().Select(PanelKey).ToHashSet();
                 foreach (var staleKey in _streams.Keys.Where(k => !liveKeys.Contains(k)).ToList())
                     if (_streams.TryRemove(staleKey, out var cts))
+                    {
                         cts.Cancel();
+                        cts.Dispose();
+                    }
 
                 if (panel.EnableStreaming && panel.IsPopOutSuccess == true)
                     StartPanelStream(panel);
@@ -202,6 +205,7 @@ namespace MSFSPopoutPanelManager.Orchestration
         private void StopServer()
         {
             _serverCts?.Cancel();
+            _serverCts?.Dispose();
             _serverCts = null;
             _tcpListener?.Stop();
             _tcpListener = null;
@@ -406,7 +410,10 @@ namespace MSFSPopoutPanelManager.Orchestration
         {
             var key = PanelKey(panel);
             if (_streams.TryRemove(key, out var cts))
+            {
                 cts.Cancel();
+                cts.Dispose();
+            }
 
             if (ProfileData?.ActiveProfile?.IsLocked == true)
                 RestorePanel(panel);

--- a/Orchestration/StreamingOrchestrator.cs
+++ b/Orchestration/StreamingOrchestrator.cs
@@ -398,11 +398,12 @@ namespace MSFSPopoutPanelManager.Orchestration
         private void StartPanelStream(PanelConfig panel)
         {
             var key = PanelKey(panel);
-            if (_streams.ContainsKey(key)) return;
 
             if (ProfileData?.ActiveProfile?.IsLocked == true)
                 MoveOffScreen(panel);
 
+            if (_streams.ContainsKey(key)) return;
+            
             _streams[key] = new CancellationTokenSource();
         }
 

--- a/Orchestration/StreamingOrchestrator.cs
+++ b/Orchestration/StreamingOrchestrator.cs
@@ -9,7 +9,9 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -24,8 +26,8 @@ namespace MSFSPopoutPanelManager.Orchestration
         // Slug → cancellation token (presence means panel is available to stream)
         readonly ConcurrentDictionary<string, CancellationTokenSource> _streams = new();
 
-        HttpListener _listener;
-        Thread _listenerThread;
+        TcpListener _tcpListener;
+        CancellationTokenSource _serverCts;
         int _port;
 
         readonly PanelPopOutOrchestrator _popOutOrchestrator;
@@ -42,10 +44,10 @@ namespace MSFSPopoutPanelManager.Orchestration
                 if (e.PropertyName != nameof(StreamingSetting.Port)) return;
                 if (!AppSettingData.ApplicationSetting.StreamingSetting.IsEnabled) return;
                 _port = AppSettingData.ApplicationSetting.StreamingSetting.Port;
-                Task.Run(() =>
+                Task.Run(async () =>
                 {
-                    _listener?.Stop();
-                    _listener = null;
+                    StopServer();
+                    await Task.Delay(200); // allow OS to release the port
                     EnsureListenerRunning();
                 });
             };
@@ -126,16 +128,39 @@ namespace MSFSPopoutPanelManager.Orchestration
             }
             else
             {
-                _listener?.Stop();
-                _listener = null;
+                StopServer();
                 if (ProfileData?.ActiveProfile == null) return;
                 foreach (var panel in ProfileData.ActiveProfile.PanelConfigs.ToList())
                     StopPanelStream(panel);
             }
         }
 
+        private string StreamHost
+        {
+            get
+            {
+                var ov = AppSettingData.ApplicationSetting.StreamingSetting.HostOverride?.Trim();
+                if (!string.IsNullOrEmpty(ov)) return ov;
+
+                var hostname = Dns.GetHostName();
+                if (string.Equals(hostname, "localhost", StringComparison.OrdinalIgnoreCase))
+                    hostname = DetectLanIp() ?? hostname;
+                return hostname;
+            }
+        }
+
+        private static string DetectLanIp()
+        {
+            foreach (var addr in Dns.GetHostAddresses(Dns.GetHostName()))
+                if (addr.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(addr))
+                    return addr.ToString();
+            return null;
+        }
+
+        public string GetIndexUrl() => $"http://{StreamHost}:{_port}/";
+
         public string GetStreamUrl(PanelConfig panel) =>
-            $"http://localhost:{_port}/stream/{PanelKey(panel)}/";
+            $"http://{StreamHost}:{_port}/stream/{PanelKey(panel)}/";
 
         private void OnPopOutCompleted(object sender, EventArgs e)
         {
@@ -160,122 +185,149 @@ namespace MSFSPopoutPanelManager.Orchestration
 
         private void EnsureListenerRunning()
         {
-            if (_listener != null && _listener.IsListening) return;
-
+            if (_tcpListener != null) return;
             try
             {
-                _listener?.Stop();
-                _listener = new HttpListener();
-                _listener.Prefixes.Add($"http://localhost:{_port}/");
-                _listener.Start();
-
-                _listenerThread = new Thread(ListenLoop) { IsBackground = true, Name = "StreamListener" };
-                _listenerThread.Start();
+                _serverCts = new CancellationTokenSource();
+                _tcpListener = new TcpListener(IPAddress.Any, _port);
+                _tcpListener.Start();
+                Task.Run(() => AcceptLoop(_serverCts.Token));
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"StreamingOrchestrator: failed to start listener: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"StreamingOrchestrator: failed to start server: {ex.Message}");
             }
         }
 
-        private void ListenLoop()
+        private void StopServer()
         {
-            while (_listener?.IsListening == true)
+            _serverCts?.Cancel();
+            _serverCts = null;
+            _tcpListener?.Stop();
+            _tcpListener = null;
+        }
+
+        private async Task AcceptLoop(CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested)
             {
                 try
                 {
-                    var ctx = _listener.GetContext();
-                    ThreadPool.QueueUserWorkItem(_ => HandleRequest(ctx));
+                    var client = await _tcpListener.AcceptTcpClientAsync(ct);
+                    _ = Task.Run(() => HandleClient(client, ct), CancellationToken.None);
                 }
                 catch { break; }
             }
         }
 
-        private void HandleRequest(HttpListenerContext ctx)
+        private async Task HandleClient(TcpClient client, CancellationToken serverCt)
         {
-            var path = ctx.Request.Url?.AbsolutePath ?? "";
-            var parts = path.Trim('/').Split('/');
-
-            if (parts.Length >= 2 && parts[0] == "stream")
+            using (client)
+            using (var stream = client.GetStream())
+            using (var handshakeCts = CancellationTokenSource.CreateLinkedTokenSource(serverCt))
             {
-                var panel = FindPanelById(parts[1]);
-                if (panel != null) ServeMjpeg(ctx, panel);
-                else Respond404(ctx);
-                return;
-            }
+                handshakeCts.CancelAfter(TimeSpan.FromSeconds(5));
+                var ct = handshakeCts.Token;
+                try
+                {
+                    var requestLine = await ReadLineAsync(stream, ct);
+                    if (string.IsNullOrEmpty(requestLine)) return;
 
-            if (parts.Length >= 2 && parts[0] == "snapshot")
-            {
-                var panel = FindPanelById(parts[1]);
-                if (panel != null) ServeSnapshot(ctx, panel);
-                else Respond404(ctx);
-                return;
-            }
+                    // Drain request headers
+                    string headerLine;
+                    while (!string.IsNullOrEmpty(headerLine = await ReadLineAsync(stream, ct))) { }
 
-            if (path == "/" || path == "")
-            {
-                ServeIndex(ctx);
-                return;
-            }
+                    // Parse "GET /path HTTP/1.1" — strip query string and trim slashes
+                    var tokens = requestLine.Split(' ');
+                    if (tokens.Length < 2) return;
+                    var rawPath = tokens[1].Split('?')[0].Trim('/');
+                    var parts = rawPath.Split('/');
 
-            Respond404(ctx);
+                    if (rawPath == "")
+                        await ServeIndex(stream, serverCt);
+                    else if (parts.Length >= 2 && parts[0] == "stream")
+                        await ServeMjpeg(stream, parts[1], serverCt);
+                    else if (parts.Length >= 2 && parts[0] == "snapshot")
+                        await ServeSnapshot(stream, parts[1]);
+                    else
+                        await stream.WriteAsync(Encoding.ASCII.GetBytes("HTTP/1.1 404 Not Found\r\n\r\n"), serverCt);
+                }
+                catch { }
+            }
         }
 
-        private void ServeMjpeg(HttpListenerContext ctx, PanelConfig panel)
+        private static async Task<string> ReadLineAsync(NetworkStream stream, CancellationToken ct)
         {
-            const string boundary = "mjpegframe";
-            ctx.Response.ContentType = $"multipart/x-mixed-replace; boundary={boundary}";
-            ctx.Response.StatusCode = 200;
-
-            if (!_streams.TryGetValue(PanelKey(panel), out var cts))
+            var sb = new StringBuilder();
+            var buf = new byte[1];
+            while (true)
             {
-                ctx.Response.Close();
+                int n = await stream.ReadAsync(buf, 0, 1, ct);
+                if (n == 0) return null;
+                char c = (char)buf[0];
+                if (c == '\n') return sb.ToString().TrimEnd('\r');
+                if (sb.Length < 4096) sb.Append(c); else return null;
+            }
+        }
+
+        private async Task ServeMjpeg(NetworkStream stream, string key, CancellationToken serverCt)
+        {
+            var panel = FindPanelById(key);
+            if (panel == null || !_streams.TryGetValue(key, out var cts))
+            {
+                await stream.WriteAsync(Encoding.ASCII.GetBytes("HTTP/1.1 404 Not Found\r\n\r\n"), serverCt);
                 return;
             }
 
+            const string boundary = "mjpegframe";
+            await stream.WriteAsync(Encoding.ASCII.GetBytes(
+                $"HTTP/1.1 200 OK\r\nContent-Type: multipart/x-mixed-replace; boundary={boundary}\r\n\r\n"), serverCt);
+
             var (codec, ep) = JpegParams(80);
-            using var stream = ctx.Response.OutputStream;
-            using var writer = new StreamWriter(stream) { AutoFlush = true };
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, serverCt);
+            var token = linked.Token;
 
             try
             {
-                while (!cts.Token.IsCancellationRequested)
+                while (!token.IsCancellationRequested)
                 {
                     using var bmp = Capture(panel.PanelHandle);
-                    if (bmp == null) { Thread.Sleep(100); continue; }
+                    if (bmp == null) { await Task.Delay(100, token); continue; }
 
                     using var ms = new MemoryStream();
                     bmp.Save(ms, codec, ep);
                     var jpg = ms.ToArray();
 
-                    writer.Write($"\r\n--{boundary}\r\nContent-Type: image/jpeg\r\nContent-Length: {jpg.Length}\r\n\r\n");
-                    writer.Flush();
-                    stream.Write(jpg, 0, jpg.Length);
-                    stream.Flush();
+                    await stream.WriteAsync(Encoding.ASCII.GetBytes(
+                        $"\r\n--{boundary}\r\nContent-Type: image/jpeg\r\nContent-Length: {jpg.Length}\r\n\r\n"), token);
+                    await stream.WriteAsync(jpg, token);
+                    await stream.FlushAsync(token);
 
-                    Thread.Sleep(33);
+                    await Task.Delay(33, token);
                 }
             }
-            catch { }
+            catch (OperationCanceledException) { }
         }
 
-        private void ServeSnapshot(HttpListenerContext ctx, PanelConfig panel)
+        private async Task ServeSnapshot(NetworkStream stream, string key)
         {
+            var panel = FindPanelById(key);
+            if (panel == null) { await stream.WriteAsync(Encoding.ASCII.GetBytes("HTTP/1.1 404 Not Found\r\n\r\n")); return; }
+
             using var bmp = Capture(panel.PanelHandle);
-            if (bmp == null) { Respond404(ctx); return; }
+            if (bmp == null) { await stream.WriteAsync(Encoding.ASCII.GetBytes("HTTP/1.1 404 Not Found\r\n\r\n")); return; }
 
             var (codec, ep) = JpegParams(95);
             using var ms = new MemoryStream();
             bmp.Save(ms, codec, ep);
             var jpg = ms.ToArray();
 
-            ctx.Response.ContentType = "image/jpeg";
-            ctx.Response.ContentLength64 = jpg.Length;
-            ctx.Response.OutputStream.Write(jpg, 0, jpg.Length);
-            ctx.Response.Close();
+            await stream.WriteAsync(Encoding.ASCII.GetBytes(
+                $"HTTP/1.1 200 OK\r\nContent-Type: image/jpeg\r\nContent-Length: {jpg.Length}\r\n\r\n"));
+            await stream.WriteAsync(jpg);
         }
 
-        private void ServeIndex(HttpListenerContext ctx)
+        private async Task ServeIndex(NetworkStream stream, CancellationToken ct)
         {
             var panels = ProfileData?.ActiveProfile?.PanelConfigs
                 .Where(p => p.IsPopOutSuccess == true && p.EnableStreaming)
@@ -333,17 +385,10 @@ namespace MSFSPopoutPanelManager.Orchestration
 </body>
 </html>";
 
-            var bytes = System.Text.Encoding.UTF8.GetBytes(html);
-            ctx.Response.ContentType = "text/html; charset=utf-8";
-            ctx.Response.ContentLength64 = bytes.Length;
-            ctx.Response.OutputStream.Write(bytes, 0, bytes.Length);
-            ctx.Response.Close();
-        }
-
-        private static void Respond404(HttpListenerContext ctx)
-        {
-            ctx.Response.StatusCode = 404;
-            ctx.Response.Close();
+            var bytes = Encoding.UTF8.GetBytes(html);
+            await stream.WriteAsync(Encoding.ASCII.GetBytes(
+                $"HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {bytes.Length}\r\n\r\n"), ct);
+            await stream.WriteAsync(bytes, ct);
         }
 
         private void StartPanelStream(PanelConfig panel)

--- a/Orchestration/StreamingOrchestrator.cs
+++ b/Orchestration/StreamingOrchestrator.cs
@@ -1,0 +1,418 @@
+using MSFSPopoutPanelManager.DomainModel.Profile;
+using MSFSPopoutPanelManager.DomainModel.Setting;
+using MSFSPopoutPanelManager.WindowsAgent;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MSFSPopoutPanelManager.Orchestration
+{
+    public class StreamingOrchestrator : BaseOrchestrator
+    {
+        [DllImport("user32.dll")] static extern bool PrintWindow(IntPtr hwnd, IntPtr hdc, uint flags);
+        const uint PW_RENDERFULLCONTENT = 0x2;
+        const uint PW_CLIENTONLY = 0x1;
+
+        // Slug → cancellation token (presence means panel is available to stream)
+        readonly ConcurrentDictionary<string, CancellationTokenSource> _streams = new();
+
+        HttpListener _listener;
+        Thread _listenerThread;
+        int _port;
+
+        readonly PanelPopOutOrchestrator _popOutOrchestrator;
+
+        public StreamingOrchestrator(SharedStorage sharedStorage, PanelPopOutOrchestrator popOutOrchestrator) : base(sharedStorage)
+        {
+            _port = AppSettingData.ApplicationSetting.StreamingSetting.Port;
+            if (AppSettingData.ApplicationSetting.StreamingSetting.IsEnabled)
+                EnsureListenerRunning();
+            _popOutOrchestrator = popOutOrchestrator;
+            _popOutOrchestrator.OnPopOutCompleted += OnPopOutCompleted;
+            AppSettingData.ApplicationSetting.StreamingSetting.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName != nameof(StreamingSetting.Port)) return;
+                if (!AppSettingData.ApplicationSetting.StreamingSetting.IsEnabled) return;
+                _port = AppSettingData.ApplicationSetting.StreamingSetting.Port;
+                Task.Run(() =>
+                {
+                    _listener?.Stop();
+                    _listener = null;
+                    EnsureListenerRunning();
+                });
+            };
+        }
+
+        private void SubscribeToActiveProfile()
+        {
+            if (ProfileData?.ActiveProfile == null) return;
+            ProfileData.ActiveProfile.PropertyChanged -= OnActiveProfilePropertyChanged;
+            ProfileData.ActiveProfile.PropertyChanged += OnActiveProfilePropertyChanged;
+
+            foreach (var panel in ProfileData.ActiveProfile.PanelConfigs)
+            {
+                panel.PropertyChanged -= OnPanelPropertyChanged;
+                panel.PropertyChanged += OnPanelPropertyChanged;
+            }
+        }
+
+        private void OnPanelPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (sender is not PanelConfig panel) return;
+            if (!AppSettingData.ApplicationSetting.StreamingSetting.IsEnabled) return;
+
+            if (e.PropertyName == nameof(PanelConfig.EnableStreaming))
+            {
+                if (panel.EnableStreaming) StartPanelStream(panel);
+                else StopPanelStream(panel);
+                return;
+            }
+
+            if (e.PropertyName == nameof(PanelConfig.PanelName))
+            {
+                // Remove any _streams entries whose key no longer matches a live panel (i.e. the old name)
+                var liveKeys = LivePanels().Select(PanelKey).ToHashSet();
+                foreach (var staleKey in _streams.Keys.Where(k => !liveKeys.Contains(k)).ToList())
+                    if (_streams.TryRemove(staleKey, out var cts))
+                        cts.Cancel();
+
+                if (panel.EnableStreaming && panel.IsPopOutSuccess == true)
+                    StartPanelStream(panel);
+            }
+        }
+
+        private void OnActiveProfilePropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != nameof(ProfileData.ActiveProfile.IsLocked)) return;
+
+            if (ProfileData.ActiveProfile.IsLocked)
+            {
+                if (!AppSettingData.ApplicationSetting.StreamingSetting.IsEnabled) return;
+
+                // Delay to run after POPM's StartConfiguration finishes repositioning windows
+                Task.Delay(1500).ContinueWith(_ =>
+                {
+                    foreach (var panel in LivePanels())
+                        MoveOffScreen(panel);
+                });
+            }
+            else
+            {
+                foreach (var panel in LivePanels())
+                    RestorePanel(panel);
+            }
+        }
+
+        public void ApplyMasterToggle(bool isEnabled)
+        {
+            if (isEnabled)
+            {
+                EnsureListenerRunning();
+                if (ProfileData?.ActiveProfile == null) return;
+                var panels = LivePanels();
+                Task.Delay(200).ContinueWith(_ =>
+                {
+                    foreach (var panel in panels)
+                        StartPanelStream(panel);
+                });
+            }
+            else
+            {
+                _listener?.Stop();
+                _listener = null;
+                if (ProfileData?.ActiveProfile == null) return;
+                foreach (var panel in ProfileData.ActiveProfile.PanelConfigs.ToList())
+                    StopPanelStream(panel);
+            }
+        }
+
+        public string GetStreamUrl(PanelConfig panel) =>
+            $"http://localhost:{_port}/stream/{PanelKey(panel)}/";
+
+        private void OnPopOutCompleted(object sender, EventArgs e)
+        {
+            _port = AppSettingData.ApplicationSetting.StreamingSetting.Port;
+            if (AppSettingData.ApplicationSetting.StreamingSetting.IsEnabled)
+                EnsureListenerRunning();
+
+            if (ProfileData?.ActiveProfile == null) return;
+
+            SubscribeToActiveProfile();
+
+            if (!AppSettingData.ApplicationSetting.StreamingSetting.IsEnabled) return;
+
+            // Delay to run after POPM's StartConfiguration finishes repositioning windows
+            var panels = LivePanels();
+            Task.Delay(1500).ContinueWith(_ =>
+            {
+                foreach (var panel in panels)
+                    StartPanelStream(panel);
+            });
+        }
+
+        private void EnsureListenerRunning()
+        {
+            if (_listener != null && _listener.IsListening) return;
+
+            try
+            {
+                _listener?.Stop();
+                _listener = new HttpListener();
+                _listener.Prefixes.Add($"http://localhost:{_port}/");
+                _listener.Start();
+
+                _listenerThread = new Thread(ListenLoop) { IsBackground = true, Name = "StreamListener" };
+                _listenerThread.Start();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"StreamingOrchestrator: failed to start listener: {ex.Message}");
+            }
+        }
+
+        private void ListenLoop()
+        {
+            while (_listener?.IsListening == true)
+            {
+                try
+                {
+                    var ctx = _listener.GetContext();
+                    ThreadPool.QueueUserWorkItem(_ => HandleRequest(ctx));
+                }
+                catch { break; }
+            }
+        }
+
+        private void HandleRequest(HttpListenerContext ctx)
+        {
+            var path = ctx.Request.Url?.AbsolutePath ?? "";
+            var parts = path.Trim('/').Split('/');
+
+            if (parts.Length >= 2 && parts[0] == "stream")
+            {
+                var panel = FindPanelById(parts[1]);
+                if (panel != null) ServeMjpeg(ctx, panel);
+                else Respond404(ctx);
+                return;
+            }
+
+            if (parts.Length >= 2 && parts[0] == "snapshot")
+            {
+                var panel = FindPanelById(parts[1]);
+                if (panel != null) ServeSnapshot(ctx, panel);
+                else Respond404(ctx);
+                return;
+            }
+
+            if (path == "/" || path == "")
+            {
+                ServeIndex(ctx);
+                return;
+            }
+
+            Respond404(ctx);
+        }
+
+        private void ServeMjpeg(HttpListenerContext ctx, PanelConfig panel)
+        {
+            const string boundary = "mjpegframe";
+            ctx.Response.ContentType = $"multipart/x-mixed-replace; boundary={boundary}";
+            ctx.Response.StatusCode = 200;
+
+            if (!_streams.TryGetValue(PanelKey(panel), out var cts))
+            {
+                ctx.Response.Close();
+                return;
+            }
+
+            var (codec, ep) = JpegParams(80);
+            using var stream = ctx.Response.OutputStream;
+            using var writer = new StreamWriter(stream) { AutoFlush = true };
+
+            try
+            {
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    using var bmp = Capture(panel.PanelHandle);
+                    if (bmp == null) { Thread.Sleep(100); continue; }
+
+                    using var ms = new MemoryStream();
+                    bmp.Save(ms, codec, ep);
+                    var jpg = ms.ToArray();
+
+                    writer.Write($"\r\n--{boundary}\r\nContent-Type: image/jpeg\r\nContent-Length: {jpg.Length}\r\n\r\n");
+                    writer.Flush();
+                    stream.Write(jpg, 0, jpg.Length);
+                    stream.Flush();
+
+                    Thread.Sleep(33);
+                }
+            }
+            catch { }
+        }
+
+        private void ServeSnapshot(HttpListenerContext ctx, PanelConfig panel)
+        {
+            using var bmp = Capture(panel.PanelHandle);
+            if (bmp == null) { Respond404(ctx); return; }
+
+            var (codec, ep) = JpegParams(95);
+            using var ms = new MemoryStream();
+            bmp.Save(ms, codec, ep);
+            var jpg = ms.ToArray();
+
+            ctx.Response.ContentType = "image/jpeg";
+            ctx.Response.ContentLength64 = jpg.Length;
+            ctx.Response.OutputStream.Write(jpg, 0, jpg.Length);
+            ctx.Response.Close();
+        }
+
+        private void ServeIndex(HttpListenerContext ctx)
+        {
+            var panels = ProfileData?.ActiveProfile?.PanelConfigs
+                .Where(p => p.IsPopOutSuccess == true && p.EnableStreaming)
+                .ToList();
+
+            var cards = "";
+            if (panels != null)
+                foreach (var p in panels)
+                {
+                    var id = PanelKey(p);
+                    cards += $@"
+                    <a href='/stream/{id}/' class='card'>
+                        <img id='thumb-{id}' src='/snapshot/{id}/?t=0' alt='{p.PanelName}' />
+                        <div class='label'>{p.PanelName}</div>
+                    </a>";
+                }
+
+            bool noStreams = panels == null || panels.Count == 0;
+            var noStream = noStreams
+                ? "<p style='color:#aaa'>No panels are currently streaming. Click <b>Start Pop Out</b> in MSFS Pop Out Panel Manager.</p>"
+                : "";
+            var metaRefresh = noStreams ? "<meta http-equiv='refresh' content='3'>" : "";
+
+            var html = $@"<!DOCTYPE html>
+<html>
+<head>
+<meta charset='utf-8'>
+{metaRefresh}<title>MSFS Panel Streams</title>
+<style>
+  body {{ background:#1a1a1a; color:#eee; font-family:sans-serif; margin:0; padding:20px; }}
+  h2   {{ margin-bottom:20px; }}
+  .grid {{ display:flex; flex-wrap:wrap; gap:16px; }}
+  .card {{ display:block; text-decoration:none; color:#eee; background:#2a2a2a;
+           border-radius:8px; overflow:hidden; border:2px solid #444;
+           transition:border-color .2s; }}
+  .card:hover {{ border-color:#4fc3f7; }}
+  .card img {{ display:block; max-width:320px; width:100%; height:auto; }}
+  .label {{ padding:8px 12px; font-size:14px; }}
+</style>
+</head>
+<body>
+<h2>MSFS Panel Streams</h2>
+{noStream}
+<div class='grid'>{cards}</div>
+<script>
+  var t = 0;
+  setInterval(function() {{
+    t++;
+    document.querySelectorAll('.card img').forEach(function(img) {{
+      var base = img.src.split('?')[0];
+      img.src = base + '?t=' + t;
+    }});
+  }}, 2000);
+</script>
+</body>
+</html>";
+
+            var bytes = System.Text.Encoding.UTF8.GetBytes(html);
+            ctx.Response.ContentType = "text/html; charset=utf-8";
+            ctx.Response.ContentLength64 = bytes.Length;
+            ctx.Response.OutputStream.Write(bytes, 0, bytes.Length);
+            ctx.Response.Close();
+        }
+
+        private static void Respond404(HttpListenerContext ctx)
+        {
+            ctx.Response.StatusCode = 404;
+            ctx.Response.Close();
+        }
+
+        private void StartPanelStream(PanelConfig panel)
+        {
+            var key = PanelKey(panel);
+            if (_streams.ContainsKey(key)) return;
+
+            if (ProfileData?.ActiveProfile?.IsLocked == true)
+                MoveOffScreen(panel);
+
+            _streams[key] = new CancellationTokenSource();
+        }
+
+        private void StopPanelStream(PanelConfig panel)
+        {
+            var key = PanelKey(panel);
+            if (_streams.TryRemove(key, out var cts))
+                cts.Cancel();
+
+            if (ProfileData?.ActiveProfile?.IsLocked == true)
+                RestorePanel(panel);
+        }
+
+        private static void MoveOffScreen(PanelConfig panel)
+        {
+            var rect = WindowActionManager.GetWindowRectangle(panel.PanelHandle);
+            WindowActionManager.MoveWindow(panel.PanelHandle, -rect.Width - 100, 0, rect.Width, rect.Height);
+        }
+
+        private static void RestorePanel(PanelConfig panel)
+        {
+            var rect = WindowActionManager.GetWindowRectangle(panel.PanelHandle);
+            WindowActionManager.MoveWindow(panel.PanelHandle, panel.Left, panel.Top, rect.Width, rect.Height);
+        }
+
+        private Bitmap Capture(IntPtr hwnd)
+        {
+            if (hwnd == IntPtr.Zero || hwnd == IntPtr.MaxValue) return null;
+
+            var client = PInvoke.GetClientRectangle(hwnd);
+            int w = Math.Max(client.Width, 1);
+            int h = Math.Max(client.Height, 1);
+
+            var bmp = new Bitmap(w, h);
+            using var g = Graphics.FromImage(bmp);
+            var hdc = g.GetHdc();
+            PrintWindow(hwnd, hdc, PW_RENDERFULLCONTENT | PW_CLIENTONLY);
+            g.ReleaseHdc(hdc);
+            return bmp;
+        }
+
+        private IEnumerable<PanelConfig> LivePanels() =>
+            ProfileData?.ActiveProfile?.PanelConfigs
+                .Where(p => p.IsPopOutSuccess == true && p.EnableStreaming)
+                .ToList() ?? Enumerable.Empty<PanelConfig>();
+
+        private PanelConfig FindPanelById(string id) =>
+            ProfileData?.ActiveProfile?.PanelConfigs
+                .FirstOrDefault(p => PanelKey(p) == id && p.IsPopOutSuccess == true);
+
+        private static string PanelKey(PanelConfig panel) =>
+            Uri.EscapeDataString(panel.PanelName.Trim());
+
+        private static (ImageCodecInfo codec, EncoderParameters ep) JpegParams(long quality)
+        {
+            var codec = ImageCodecInfo.GetImageEncoders().First(e => e.FormatID == ImageFormat.Jpeg.Guid);
+            var ep = new EncoderParameters(1);
+            ep.Param[0] = new EncoderParameter(System.Drawing.Imaging.Encoder.Quality, quality);
+            return (codec, ep);
+        }
+    }
+}


### PR DESCRIPTION
_Hey, thanks for a super useful app! Been loving POPM since MSFS2020 and the 2020 version._

This PR enables optional streaming of the popout windows. It streams each panel as an MJPEG feed, accessible from any browser on the LAN. 

- A toggle button (next to the lock icon) enables/disables streaming
- Each panel has its own streaming setting (click the down arrow on the right to expand the settings area)
- Clicking the "open external link" icon launches the index page in the default browser
- Each individual panel can be accessed by clicking the thumbnail in the index page, the web address uses the panel name, so they can be bookmarked and stay consistent if you restart popout panel manager

Depending on your network settings, you might need to allow the HTTP port TCP traffic on your Windows firewall. **Touch events are not handled for streamed panels.** I wanted to see if the proof of concept works first.

For disclosure, I used AI to help me with the code, since I don't know .NET or csharp very well yet. However, I was careful to iterate the implementation myself, defined the UI and tested that my ideas made sense, instead of just "vibe coding" it blindly from scratch. I also wrote this whole description myself :-) I do not like to read through AI slop, so I would not do that to you either.

I can read code much better than I can write it, so I have reviewed the changes and as far as I can see, everything follows existing patterns and does not touch anything outside the scope of this feature. And the implementation is not really complicated, and I find it useful, thus here is a pull request.

## New files

`Orchestration/StreamingOrchestrator.cs` (new)
  - Core streaming service, starts the .NET built in `HttpListener` and serves index page with thumbnails of each streamed popup. Serves auto-refreshing placeholder page when panels are not yet popped out. Restarts on port change.
  - Each panel can be accessed with `/stream/panelname/` (MJPEG ~30 fps), and `/snapshot/panelname/` (single image).
  - Panel content is captured through `PrintWindow` with `PW_RENDERFULLCONTENT` and `PW_CLIENTONLY` to get a the contents of a 3D accelerated window without the frame.
  - When streaming starts and the profile is locked, streamed panels move offscreen to `x = -(width + 100), y = 0` so they are out of view but MSFS updates them. Panels are moved back if profile is unlocked to allow resizing and moving.
  - When streaming settings change, or panel names change, the HttpListener updates accordingly, or stops when streaming is disabled.

`DomainModel/Setting/StreamingSetting.cs` (new)
- Settings for streaming:`IsEnabled` to turn feature on/off, `Port` (default 8080)

## Changes to existing code

- `App.xaml.cs` added `StreamingOrchestrator`
- `ApplicationSetting.cs` added `StreamingSetting`
- `ProfileCard.xaml` / `ProfileCardViewModel.cs` 
  - Added two buttons to topright toolbar
    - Main on/off toggle for streaming feature ("cast" icon)
    - Open link icon to open the stream index page in browser
  - Use `DockPanel` for button toolbar + text label:
    - Set `DockPanel.Dock="Right"` property for the buttons' StackPanel so it floats right
    - Set the text label as last item. Apparently the order matters in DockPanel, the last item
       fills the remaining space, so we can remove the hardcoded 723px margin
- `PanelConfig.cs` / `PanelConfigItem.cs` added `EnableStreaming` boolean
- `PopOutPanelConfigCard.xaml` added toggle to enable setting for individual popups
- `PreferenceDrawer.xaml` added streaming settings page for HTTP port.
