### PR TITLE
Support ChasePlane API v2 payloads

### DIFF
--- a/WindowsAgent/ChasePlaneManager.cs
+++ b/WindowsAgent/ChasePlaneManager.cs
@@ -1,6 +1,7 @@
 ﻿using MSFSPopoutPanelManager.DomainModel.Profile;
 using MSFSPopoutPanelManager.Shared;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -16,6 +17,8 @@ namespace MSFSPopoutPanelManager.WindowsAgent
 {
     public class ChasePlaneManager
     {
+        private const int SupportedApiVersion = 2;
+
         private static ClientWebSocket _clientWebSocket;
 
         public static List<ChasePlaneView> ChasePlaneViews { get; private set; }
@@ -142,21 +145,20 @@ namespace MSFSPopoutPanelManager.WindowsAgent
                     if (!IsJson(message))
                         continue;
 
-                    var chasePlaneMessage = JsonConvert.DeserializeObject<ChasePlaneMessage>(message);
+                    var chasePlaneMessage = ChasePlaneProtocol.DeserializeMessage(message);
 
                     if (chasePlaneMessage != null && !String.IsNullOrEmpty(chasePlaneMessage.Message))
                     {
                         switch (chasePlaneMessage.Message.ToLower())
                         {
                             case "api_version":
-                                //Debug.WriteLine(message);
+                                if (!ChasePlaneProtocol.TryGetApiVersion(chasePlaneMessage, out int apiVersion) || apiVersion != SupportedApiVersion)
+                                    throw new NotSupportedException($"ChasePlane API version {apiVersion} is not supported. Version {SupportedApiVersion} is required.");
                                 break;
                             case "cam_mode_set":
                                 //Debug.WriteLine(message);
 
-                                var camModeSetMsg = JsonConvert.DeserializeObject<ChasePlaneMessage>(message);
-
-                                if(!_isViewsReady && camModeSetMsg.Payload.ViewsLoaded)
+                                if (!_isViewsReady && ChasePlaneProtocol.TryGetViewsLoaded(chasePlaneMessage, out bool viewsLoaded) && viewsLoaded)
                                 {
                                     _isViewsReady = true;
                                     _getCameraViewRetryCount = 3;
@@ -175,16 +177,14 @@ namespace MSFSPopoutPanelManager.WindowsAgent
 
                                 break;
                             case "api_reply":
-                                if (chasePlaneMessage.Payload.Message.Equals("get_views", StringComparison.InvariantCultureIgnoreCase))
+                                if (ChasePlaneProtocol.TryGetCameraViewsPayload(chasePlaneMessage, out ChasePlaneMessagePayload.ChasePlaneApiGetViewReplyPayload viewPayload))
                                 {
                                     //Debug.WriteLine(message);
 
-                                    var viewMessage = JsonConvert.DeserializeObject<ChasePlaneMessage>(message);
-
-                                    var currentAircraftName = viewMessage.Payload.Payload.MetaData.Aircraft;
+                                    var currentAircraftName = viewPayload.MetaData.Aircraft;
 
                                     var chasePlaneCameraConfigs = new List<ChasePlaneCameraConfig>();
-                                    var chasePlaneViews = viewMessage.Payload.Payload.ChasePlaneViews.FindAll(v => (v.ProfileTheme.Equals("ONBOARD_PIC", StringComparison.InvariantCultureIgnoreCase) || v.ProfileTheme.Equals("ONBOARD_SYSTEMS", StringComparison.InvariantCultureIgnoreCase)) && v.Aircraft.Equals(currentAircraftName, StringComparison.InvariantCultureIgnoreCase));
+                                    var chasePlaneViews = viewPayload.ChasePlaneViews.FindAll(v => (v.ProfileTheme.Equals("ONBOARD_PIC", StringComparison.InvariantCultureIgnoreCase) || v.ProfileTheme.Equals("ONBOARD_SYSTEMS", StringComparison.InvariantCultureIgnoreCase)) && v.Aircraft.Equals(currentAircraftName, StringComparison.InvariantCultureIgnoreCase));
                                     
                                     if (chasePlaneViews != null && chasePlaneViews.Count > 0)
                                     {
@@ -350,7 +350,7 @@ namespace MSFSPopoutPanelManager.WindowsAgent
         public string Command;
 
         [JsonProperty("payload")]
-        public ChasePlaneMessagePayload Payload;
+        public object Payload;
     }
 
     public class ChasePlaneMessagePayload
@@ -459,5 +459,65 @@ namespace MSFSPopoutPanelManager.WindowsAgent
 
         [JsonProperty("payload")]
         public ChasePlaneView Payload;
+    }
+
+    public class ChasePlaneApiVersionPayload
+    {
+        [JsonProperty("version")]
+        public int Version;
+    }
+
+    public class ChasePlaneCamModeSetPayload
+    {
+        [JsonProperty("views_loaded")]
+        public bool ViewsLoaded;
+    }
+
+    internal static class ChasePlaneProtocol
+    {
+        // Parse the message envelope before selecting a message-specific payload type.
+        public static ChasePlaneMessage DeserializeMessage(string message)
+        {
+            return JsonConvert.DeserializeObject<ChasePlaneMessage>(message);
+        }
+
+        public static bool TryGetApiVersion(ChasePlaneMessage message, out int apiVersion)
+        {
+            var payload = DeserializePayload<ChasePlaneApiVersionPayload>(message?.Payload);
+            apiVersion = payload?.Version ?? 0;
+            return apiVersion > 0;
+        }
+
+        public static bool TryGetViewsLoaded(ChasePlaneMessage message, out bool viewsLoaded)
+        {
+            var payload = DeserializePayload<ChasePlaneCamModeSetPayload>(message?.Payload);
+            viewsLoaded = payload?.ViewsLoaded ?? false;
+            return payload != null;
+        }
+
+        public static bool TryGetCameraViewsPayload(ChasePlaneMessage message, out ChasePlaneMessagePayload.ChasePlaneApiGetViewReplyPayload viewPayload)
+        {
+            viewPayload = null;
+            var nestedPayload = DeserializePayload<ChasePlaneMessagePayload>(message?.Payload);
+
+            if (nestedPayload?.Message?.Equals("get_views", StringComparison.InvariantCultureIgnoreCase) == true)
+            {
+                viewPayload = nestedPayload.Payload;
+            }
+            else if (message?.RequestId?.StartsWith("get_views_", StringComparison.InvariantCultureIgnoreCase) == true)
+            {
+                viewPayload = DeserializePayload<ChasePlaneMessagePayload.ChasePlaneApiGetViewReplyPayload>(message.Payload);
+            }
+
+            return viewPayload?.MetaData != null && viewPayload.ChasePlaneViews != null;
+        }
+
+        private static T DeserializePayload<T>(object payload) where T : class
+        {
+            if (payload is JToken token)
+                return token.ToObject<T>();
+
+            return payload == null ? null : JToken.FromObject(payload).ToObject<T>();
+        }
     }
 }


### PR DESCRIPTION
## What changed

- Require the ChasePlane public WebSocket API version 2 contract.
- Parse the message envelope before converting message-specific payloads.
- Ignore unrelated ChasePlane events whose payload is an object, array, or null.
- Preserve the existing camera filtering, retry timing, readiness signals, and commands.

## Root cause

ChasePlane API v2 sends additional public state events after `api_connect`. Some events contain array payloads. POPM deserialized every incoming payload as `ChasePlaneMessagePayload`, which requires an object, so an array event raised `JsonSerializationException` and stopped the listener.

The listener now keeps the envelope payload generic and converts it only for the messages POPM handles.

## Impact

This restores ChasePlane camera selection with the current Preview API without changing POPM's camera-selection behavior.

Fixes #84.

## Validation

- `dotnet build MSFSPopoutPanelManager.sln -c Debug --no-incremental`
- Build passed with 0 errors and the same 11 existing warnings.
- No test project was added because this repository does not currently use a test suite.
